### PR TITLE
Define CMAKE_C_FLAGS only if not defined already

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,11 @@ project( liblightmodbus
 include( TestBigEndian )
 
 #Debug/release options
-set( CMAKE_C_FLAGS "-Wall" )
-set( CMAKE_C_FLAGS_DEBUG "-g -O0 -fno-builtin" )
-set( CMAKE_C_FLAGS_RELEASE "-Os" )
+if ( NOT DEFINED CMAKE_C_FLAGS)
+	set( CMAKE_C_FLAGS "-Wall" )
+	set( CMAKE_C_FLAGS_DEBUG "-g -O0 -fno-builtin" )
+	set( CMAKE_C_FLAGS_RELEASE "-Os" )
+endif()
 
 # Clang generates some warnings when building with static memory allocation
 # These warnings are obviously correct, but they are also harmless


### PR DESCRIPTION
I'm building for Atmel SAMR34, so in my case I already defined `CMAKE_C_FLAGS`, so it would be nice to be able to use my own :)