### PR TITLE
Added ESP-IDF support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,6 @@ string( REGEX REPLACE "\n$" "" PROJECT_GIT_VERSION "${PROJECT_GIT_VERSION}" ) #S
 
 #Esp-idf specific configuration
 if (ESP_PLATFORM) 
-    idf_component_register(
-        SRC_DIRS src src/slave src/master
-        INCLUDE_DIRS include .
-    )
-
     # ESP32 is a little endian chip
     set(LIBCONF "\n#include \"sdkconfig.h\"\n\n")
     set(LIBCONF "${LIBCONF}#define LIGHTMODBUS_LITTLE_ENDIAN\n")
@@ -69,11 +64,21 @@ if (ESP_PLATFORM)
     set(LIBCONF "${LIBCONF}#ifdef CONFIG_LIGHTMODBUS_MEM_MASTER_REQUEST_ENABLED\n#define LIGHTMODBUS_MEM_MASTER_REQUEST CONFIG_LIGHTMODBUS_MEM_MASTER_REQUEST\n#endif\n")
     set(LIBCONF "${LIBCONF}#ifdef CONFIG_LIGHTMODBUS_MEM_MASTER_RESPONSE_ENABLED\n#define LIGHTMODBUS_MEM_MASTER_RESPONSE CONFIG_LIGHTMODBUS_MEM_MASTER_RESPONSE\n#endif\n")
 
+    file(MAKE_DIRECTORY ${BUILD_DIR}/lightmodbus)
+    file(MAKE_DIRECTORY ${BUILD_DIR}/lightmodbus/slave)
+    file(MAKE_DIRECTORY ${BUILD_DIR}/lightmodbus/master)
+
     #Emit configuration file
     configure_file(
         "${COMPONENT_DIR}/include/lightmodbus/libconf.h.in"
-        "${COMPONENT_DIR}/include/lightmodbus/libconf.h"
+        "${BUILD_DIR}/lightmodbus/libconf.h"
     )
+
+    idf_component_register(
+        SRC_DIRS src src/slave src/master
+        INCLUDE_DIRS include . ${BUILD_DIR}/lightmodbus ${BUILD_DIR}/lightmodbus/master ${BUILD_DIR}/lightmodbus/slave
+    )
+
     return()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,82 @@
+#List of all slave modules
+set( SLAVE_MODULES
+	"F01S"
+	"F02S"
+	"F03S"
+	"F04S"
+	"F05S"
+	"F06S"
+	"F15S"
+	"F16S"
+	"F22S"
+	"SLAVE_USER_FUNCTIONS"
+	"REGISTER_CALLBACK"
+	"COIL_CALLBACK"
+)
+
+#List of all master modules
+set( MASTER_MODULES
+	"F01M"
+	"F02M"
+	"F03M"
+	"F04M"
+	"F05M"
+	"F06M"
+	"F15M"
+	"F16M"
+	"F22M"
+	"MASTER_USER_FUNCTIONS"
+	"NO_MASTER_DATA_BUFFER"
+	"MASTER_INVASIVE_PARSING"
+)
+
+#List of all modules that can be enabled
+set( AVAILABLE_MODULES
+	"SLAVE_BASE"
+	"${SLAVE_MODULES}"
+	"MASTER_BASE"
+	"${MASTER_MODULES}"
+
+	#Misc
+	"EXPERIMENTAL"
+)
+
+#Get git version (LIGHTMODBUS_GIT_VERSION)
+execute_process( COMMAND "git" "describe" "--abbrev=6" "--dirty" "--always" "--tag" RESULT_VARIABLE GIT_EXIT_CODE OUTPUT_VARIABLE PROJECT_GIT_VERSION )
+if ( GIT_EXIT_CODE )
+    set( PROJECT_GIT_VERSION "no-vcs-found" )
+endif( )
+string( REGEX REPLACE "\n$" "" PROJECT_GIT_VERSION "${PROJECT_GIT_VERSION}" ) #Strip newline
+
+#Esp-idf specific configuration
+if (ESP_PLATFORM) 
+    idf_component_register(
+        SRC_DIRS src src/slave src/master
+        INCLUDE_DIRS include .
+    )
+
+    # ESP32 is a little endian chip
+    set(LIBCONF "\n#include \"sdkconfig.h\"\n\n")
+    set(LIBCONF "${LIBCONF}#define LIGHTMODBUS_LITTLE_ENDIAN\n")
+
+    foreach(MODULE ${AVAILABLE_MODULES})
+        set(LIBCONF "${LIBCONF}#ifdef CONFIG_LIGHTMODBUS_${MODULE}\n#define LIGHTMODBUS_${MODULE}\n#endif\n")
+    endforeach()
+
+    # static memory allocation buffers
+    set(LIBCONF "${LIBCONF}#ifdef CONFIG_LIGHTMODBUS_MEM_SLAVE_REQUEST_ENABLED\n#define LIGHTMODBUS_MEM_SLAVE_REQUEST CONFIG_LIGHTMODBUS_MEM_SLAVE_REQUEST\n#endif\n")
+    set(LIBCONF "${LIBCONF}#ifdef CONFIG_LIGHTMODBUS_MEM_SLAVE_RESPONSE_ENABLED\n#define LIGHTMODBUS_MEM_SLAVE_RESPONSE CONFIG_LIGHTMODBUS_MEM_SLAVE_RESPONSE\n#endif\n")
+    set(LIBCONF "${LIBCONF}#ifdef CONFIG_LIGHTMODBUS_MEM_MASTER_REQUEST_ENABLED\n#define LIGHTMODBUS_MEM_MASTER_REQUEST CONFIG_LIGHTMODBUS_MEM_MASTER_REQUEST\n#endif\n")
+    set(LIBCONF "${LIBCONF}#ifdef CONFIG_LIGHTMODBUS_MEM_MASTER_RESPONSE_ENABLED\n#define LIGHTMODBUS_MEM_MASTER_RESPONSE CONFIG_LIGHTMODBUS_MEM_MASTER_RESPONSE\n#endif\n")
+
+    #Emit configuration file
+    configure_file(
+        "${COMPONENT_DIR}/include/lightmodbus/libconf.h.in"
+        "${COMPONENT_DIR}/include/lightmodbus/libconf.h"
+    )
+    return()
+endif()
+
 #Basic stuff
 cmake_minimum_required( VERSION 3.3 )
 project( liblightmodbus
@@ -60,58 +139,8 @@ if ( DEFINED AVR )
 	set( ENDIANNESS "little" )
 endif( )
 
-#Get git version (LIGHTMODBUS_GIT_VERSION)
-execute_process( COMMAND "git" "describe" "--abbrev=6" "--dirty" "--always" "--tag" RESULT_VARIABLE GIT_EXIT_CODE OUTPUT_VARIABLE PROJECT_GIT_VERSION )
-if ( GIT_EXIT_CODE )
-	set( PROJECT_GIT_VERSION "no-vcs-found" )
-endif( )
-string( REGEX REPLACE "\n$" "" PROJECT_GIT_VERSION "${PROJECT_GIT_VERSION}" ) #Strip newline
-
 #Include dirs
 include_directories( "${PROJECT_SOURCE_DIR}/include" )
-
-#List of all slave modules
-set( SLAVE_MODULES
-	"F01S"
-	"F02S"
-	"F03S"
-	"F04S"
-	"F05S"
-	"F06S"
-	"F15S"
-	"F16S"
-	"F22S"
-	"SLAVE_USER_FUNCTIONS"
-	"REGISTER_CALLBACK"
-	"COIL_CALLBACK"
-)
-
-#List of all master modules
-set( MASTER_MODULES
-	"F01M"
-	"F02M"
-	"F03M"
-	"F04M"
-	"F05M"
-	"F06M"
-	"F15M"
-	"F16M"
-	"F22M"
-	"MASTER_USER_FUNCTIONS"
-	"NO_MASTER_DATA_BUFFER"
-	"MASTER_INVASIVE_PARSING"
-)
-
-#List of all modules that can be enabled
-set( AVAILABLE_MODULES
-	"SLAVE_BASE"
-	"${SLAVE_MODULES}"
-	"MASTER_BASE"
-	"${MASTER_MODULES}"
-
-	#Misc
-	"EXPERIMENTAL"
-)
 
 #List of modules enabled by default
 set( DEFAULT_MODULES

--- a/Kconfig
+++ b/Kconfig
@@ -3,12 +3,14 @@ menu "Liblightmodbus"
     config LIGHTMODBUS_SLAVE_BASE
         bool "Slave module"
         help
-            This enables the slave module
+            Enables the slave module
         default y
 
     config LIGHTMODBUS_STATIC_MEM_SLAVE_REQUEST_ENABLED
         depends on LIGHTMODBUS_SLAVE_BASE
-        bool "Enable static memory allocation for slave requests"
+        bool "Static request allocation"
+        help
+            Enable static memory allocation for slave requests
 
     config LIGHTMODBUS_STATIC_MEM_SLAVE_REQUEST
         depends on LIGHTMODBUS_SLAVE_BASE && LIGHTMODBUS_STATIC_MEM_SLAVE_REQUEST_ENABLED
@@ -19,7 +21,9 @@ menu "Liblightmodbus"
 
     config LIGHTMODBUS_STATIC_MEM_SLAVE_RESPONSE_ENABLED
         depends on LIGHTMODBUS_SLAVE_BASE
-        bool "Enable static memory allocation for slave requests"
+        bool "Static response allocation"
+        help
+            Enable static memory allocation for slave responses
 
     config LIGHTMODBUS_STATIC_MEM_SLAVE_RESPONSE
         depends on LIGHTMODBUS_SLAVE_BASE && LIGHTMODBUS_STATIC_MEM_SLAVE_RESPONSE_ENABLED
@@ -74,15 +78,19 @@ menu "Liblightmodbus"
         depends on LIGHTMODBUS_SLAVE_BASE
         bool "Slave user functions"
         help
-            Support for user-defined Modbus functions on slave side
+            Support for user-defined Modbus function behavior on the slave side
 
     config REGISTER_CALLBACK
         depends on LIGHTMODBUS_SLAVE_BASE
         bool "Slave register callback function"
+        help
+            Support for user-defined callbacks for register access
 
     config COIL_CALLBACK
         depends on LIGHTMODBUS_SLAVE_BASE
         bool "Slave coil callback function"
+        help
+            Support for user-defined callbacks for coil access
     
     config LIGHTMODBUS_MASTER_BASE
         bool "Master module"
@@ -92,7 +100,9 @@ menu "Liblightmodbus"
 
     config LIGHTMODBUS_STATIC_MEM_MASTER_REQUEST_ENABLED
         depends on LIGHTMODBUS_MASTER_BASE
-        bool "Enable static memory allocation for master requests"
+        bool "Static request allocation"
+        help
+            Enable static memory allocation for master requests
 
     config LIGHTMODBUS_STATIC_MEM_MASTER_REQUEST
         depends on LIGHTMODBUS_MASTER_BASE && LIGHTMODBUS_STATIC_MEM_MASTER_REQUEST_ENABLED
@@ -103,12 +113,14 @@ menu "Liblightmodbus"
 
     config LIGHTMODBUS_STATIC_MEM_MASTER_RESPONSE_ENABLED
         depends on LIGHTMODBUS_MASTER_BASE
-        bool "Enable static memory allocation for master requests"
+        bool "Static response allocation"
+        help
+            Enable static memory allocation for master responses
 
     config LIGHTMODBUS_STATIC_MEM_MASTER_RESPONSE
         depends on LIGHTMODBUS_MASTER_BASE && LIGHTMODBUS_STATIC_MEM_MASTER_RESPONSE_ENABLED
         int
-	    prompt "Statically allocated buffer size for slave responses"
+	    prompt "Statically allocated buffer size for master responses"
 	    range 3 4294967295
 	    default 32
 
@@ -158,13 +170,13 @@ menu "Liblightmodbus"
         depends on LIGHTMODBUS_MASTER_BASE
         bool "Master user functions"
         help
-            Support for user-defined Modbus functions on master side
+            Support for user-defined Modbus function behavior on the master side
 
     config LIGHTMODBUS_NO_MASTER_DATA_BUFFER
         depends on LIGHTMODBUS_MASTER_BASE && LIGHTMODBUS_EXPERIMENTAL
         bool "No master data buffer"
         help
-            Support for user-defined Modbus functions on master side
+            No storage for incoming data will be allocated. Instead the ModbusMaster::data's coil and regs pointers point to where the regsiter/coil data starts in the ModbusMaster::response frame
 
     config LIGHTMODBUS_MASTER_INVASIVE_PARSING
         depends on LIGHTMODBUS_MASTER_BASE && LIGHTMODBUS_NO_MASTER_DATA_BUFFER

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,178 @@
+menu "Liblightmodbus"
+    
+    config LIGHTMODBUS_SLAVE_BASE
+        bool "Slave module"
+        help
+            This enables the slave module
+        default y
+
+    config LIGHTMODBUS_STATIC_MEM_SLAVE_REQUEST_ENABLED
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Enable static memory allocation for slave requests"
+
+    config LIGHTMODBUS_STATIC_MEM_SLAVE_REQUEST
+        depends on LIGHTMODBUS_SLAVE_BASE && LIGHTMODBUS_STATIC_MEM_SLAVE_REQUEST_ENABLED
+        int
+	    prompt "Statically allocated buffer size for slave requests"
+	    range 3 4294967295
+        default 32
+
+    config LIGHTMODBUS_STATIC_MEM_SLAVE_RESPONSE_ENABLED
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Enable static memory allocation for slave requests"
+
+    config LIGHTMODBUS_STATIC_MEM_SLAVE_RESPONSE
+        depends on LIGHTMODBUS_SLAVE_BASE && LIGHTMODBUS_STATIC_MEM_SLAVE_RESPONSE_ENABLED
+        int
+	    prompt "Statically allocated buffer size for slave responses"
+	    range 3 4294967295
+	    default 32
+
+    config LIGHTMODBUS_F01S
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave function code 1"
+        default y
+
+    config LIGHTMODBUS_F02S
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave function code 2"
+        default y
+
+    config LIGHTMODBUS_F03S
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave function code 3"
+        default y
+
+    config LIGHTMODBUS_F04S
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave function code 4"
+        default y
+
+    config LIGHTMODBUS_F05S
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave function code 5"
+        default y
+
+    config LIGHTMODBUS_F06S
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave function code 6"
+        default y
+
+    config LIGHTMODBUS_F15S
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave function code 15"
+
+    config LIGHTMODBUS_F16S
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave function code 16"
+
+    config LIGHTMODBUS_F22S
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave function code 22"
+
+    config SLAVE_USER_FUNCTIONS
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave user functions"
+        help
+            Support for user-defined Modbus functions on slave side
+
+    config REGISTER_CALLBACK
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave register callback function"
+
+    config COIL_CALLBACK
+        depends on LIGHTMODBUS_SLAVE_BASE
+        bool "Slave coil callback function"
+    
+    config LIGHTMODBUS_MASTER_BASE
+        bool "Master module"
+        help
+            This enables the master module
+        default y
+
+    config LIGHTMODBUS_STATIC_MEM_MASTER_REQUEST_ENABLED
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Enable static memory allocation for master requests"
+
+    config LIGHTMODBUS_STATIC_MEM_MASTER_REQUEST
+        depends on LIGHTMODBUS_MASTER_BASE && LIGHTMODBUS_STATIC_MEM_MASTER_REQUEST_ENABLED
+        int
+	    prompt "Statically allocated buffer size for master requests"
+	    range 3 4294967295
+        default 32
+
+    config LIGHTMODBUS_STATIC_MEM_MASTER_RESPONSE_ENABLED
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Enable static memory allocation for master requests"
+
+    config LIGHTMODBUS_STATIC_MEM_MASTER_RESPONSE
+        depends on LIGHTMODBUS_MASTER_BASE && LIGHTMODBUS_STATIC_MEM_MASTER_RESPONSE_ENABLED
+        int
+	    prompt "Statically allocated buffer size for slave responses"
+	    range 3 4294967295
+	    default 32
+
+    config LIGHTMODBUS_F01M
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Master function code 1"
+        default y
+
+    config LIGHTMODBUS_F02M
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Master function code 2"
+        default y
+
+    config LIGHTMODBUS_F03M
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Master function code 3"
+        default y
+
+    config LIGHTMODBUS_F04M
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Master function code 4"
+        default y
+
+    config LIGHTMODBUS_F05M
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Master function code 5"
+        default y
+
+    config LIGHTMODBUS_F06M
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Master function code 6"
+        default y
+
+    config LIGHTMODBUS_F15M
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Master function code 15"
+
+    config LIGHTMODBUS_F16M
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Master function code 16"
+
+    config LIGHTMODBUS_F22M
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Master function code 22"
+
+    config LIGHTMODBUS_MASTER_USER_FUNCTIONS
+        depends on LIGHTMODBUS_MASTER_BASE
+        bool "Master user functions"
+        help
+            Support for user-defined Modbus functions on master side
+
+    config LIGHTMODBUS_NO_MASTER_DATA_BUFFER
+        depends on LIGHTMODBUS_MASTER_BASE && LIGHTMODBUS_EXPERIMENTAL
+        bool "No master data buffer"
+        help
+            Support for user-defined Modbus functions on master side
+
+    config LIGHTMODBUS_MASTER_INVASIVE_PARSING
+        depends on LIGHTMODBUS_MASTER_BASE && LIGHTMODBUS_NO_MASTER_DATA_BUFFER
+        bool "Master invasive parsing"
+        help
+            Allow master to modify received frame
+
+    config LIGHTMODBUS_EXPERIMENTAL
+        bool "Enable experimental features"
+
+    endmenu


### PR DESCRIPTION
Refers to #17 .

I added two things:

 - an if branch with minimal ESP-IDF configuration to be entered if cmake is invoked via `idf.py`. With this, adding liblightmodbus to the `components` directory of an esp32 project is all that is needed to include it. The remaining functionality is unchanged. I also moved some variable declaration on top to be used by the conditional branch.
 - a `Kconfig` file. ESP-IDF can parse kconfig files and show their options in a global menuconfig interface. The resulting options are then expressed as global variables in the Cmake environment and as macros in `sdkconfig.h`. If the environment is run by ESP-IDF the `libconf.h` file now refers to `sdkconfig.h` for the configuration.

![output](https://user-images.githubusercontent.com/14563868/97081385-71355b80-1602-11eb-815a-763f00cdc817.gif)

The remaining functionality should be unchanged.