### PR TITLE
inttypes.h replaced with stdint.h

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <inttypes.h>
+#include <stdint.h>
 
 #include <lightmodbus/lightmodbus.h>
 #include <lightmodbus/master.h>

--- a/include/lightmodbus/addons/examine.h
+++ b/include/lightmodbus/addons/examine.h
@@ -21,7 +21,7 @@
 #ifndef LIGHTMODBUS_EXAMINE
 #define LIGHTMODBUS_EXAMINE
 
-#include <inttypes.h>
+#include <stdint.h>
 #include "../lightmodbus.h"
 #include "../libconf.h"
 

--- a/include/lightmodbus/lightmodbus.h
+++ b/include/lightmodbus/lightmodbus.h
@@ -35,7 +35,7 @@ extern "C" {
 #endif
 
 //Include proper header files
-#include <inttypes.h>
+#include <stdint.h>
 #include "libconf.h"
 
 //Some protection

--- a/include/lightmodbus/master.h
+++ b/include/lightmodbus/master.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-#include <inttypes.h>
+#include <stdint.h>
 #include "parser.h"
 #include "libconf.h"
 #include "lightmodbus.h"

--- a/include/lightmodbus/master/mbcoils.h
+++ b/include/lightmodbus/master/mbcoils.h
@@ -26,7 +26,7 @@
 #ifndef LIGHTMODBUS_MBCOILS_H
 #define LIGHTMODBUS_MBCOILS_H
 
-#include <inttypes.h>
+#include <stdint.h>
 #include "../libconf.h"
 #include "../lightmodbus.h"
 #include "../master.h"

--- a/include/lightmodbus/master/mbregs.h
+++ b/include/lightmodbus/master/mbregs.h
@@ -26,7 +26,7 @@
 #ifndef LIGHTMODBUS_MBREGS_H
 #define LIGHTMODBUS_MBREGS_H
 
-#include <inttypes.h>
+#include <stdint.h>
 #include "../libconf.h"
 #include "../lightmodbus.h"
 #include "../master.h"

--- a/include/lightmodbus/master/mpcoils.h
+++ b/include/lightmodbus/master/mpcoils.h
@@ -26,7 +26,7 @@
 #ifndef LIGHTMODBUS_MPCOILS_H
 #define LIGHTMODBUS_MPCOILS_H
 
-#include <inttypes.h>
+#include <stdint.h>
 #include "../libconf.h"
 #include "../lightmodbus.h"
 #include "../master.h"

--- a/include/lightmodbus/master/mpregs.h
+++ b/include/lightmodbus/master/mpregs.h
@@ -26,7 +26,7 @@
 #ifndef LIGHTMODBUS_MPREGS_H
 #define LIGHTMODBUS_MPREGS_H
 
-#include <inttypes.h>
+#include <stdint.h>
 #include "../libconf.h"
 #include "../lightmodbus.h"
 #include "../master.h"

--- a/include/lightmodbus/parser.h
+++ b/include/lightmodbus/parser.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-#include <inttypes.h>
+#include <stdint.h>
 #include "libconf.h"
 
 

--- a/include/lightmodbus/slave.h
+++ b/include/lightmodbus/slave.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-#include <inttypes.h>
+#include <stdint.h>
 #include <stddef.h>
 #include "parser.h"
 #include "libconf.h"

--- a/include/lightmodbus/slave/scoils.h
+++ b/include/lightmodbus/slave/scoils.h
@@ -26,7 +26,7 @@
 #ifndef LIGHTMODBUS_SCOILS_H
 #define LIGHTMODBUS_SCOILS_H
 
-#include <inttypes.h>
+#include <stdint.h>
 #include "../libconf.h"
 #include "../lightmodbus.h"
 #include "../slave.h"

--- a/include/lightmodbus/slave/sregs.h
+++ b/include/lightmodbus/slave/sregs.h
@@ -26,7 +26,7 @@
 #ifndef LIGHTMODBUS_SREGS_H
 #define LIGHTMODBUS_SREGS_H
 
-#include <inttypes.h>
+#include <stdint.h>
 #include "../libconf.h"
 #include "../lightmodbus.h"
 #include "../slave.h"

--- a/test/test.c
+++ b/test/test.c
@@ -7,7 +7,7 @@ AKA. The Worst Test File Ever
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-#include <inttypes.h>
+#include <stdint.h>
 
 #include <lightmodbus/lightmodbus.h>
 #include <lightmodbus/master.h>


### PR DESCRIPTION
Using liblightmodbus on a Microchip MCU (PIC24) the xc16 compiler doesnt include the header inttypes.h, so I replaced it with the inclusion of stdint.h in 13 files
