### PR TITLE
Explicit initialization of variables

### DIFF
--- a/include/lightmodbus/master.impl.h
+++ b/include/lightmodbus/master.impl.h
@@ -68,7 +68,7 @@ const uint8_t modbusMasterDefaultFunctionCount = sizeof(modbusMasterDefaultFunct
 	\param dataCallback Callback function for handling incoming data (may be required by used parsing functions)
 	\param exceptionCallback Callback function for handling slave exceptions (optional)
 	\param allocator Memory allocator to be used (see \ref modbusDefaultAllocator()) (required)
-	\param functions Pointer to an array of supported function handlers (required). 
+	\param functions Pointer to an array of supported function handlers (required).
 		The lifetime of this array must not be shorter than the lifetime of the master.
 	\param functionCount Number of elements in the `functions` array (required)
 	\returns MODBUS_NO_ERROR() on success
@@ -144,7 +144,7 @@ LIGHTMODBUS_RET_ERROR modbusEndRequestRTU(ModbusMaster *status, uint8_t address)
 		&status->request.data[0],
 		status->request.length,
 		address);
-	
+
 	if (err != MODBUS_OK)
 		return MODBUS_MAKE_ERROR(MODBUS_ERROR_SOURCE_GENERAL, err);
 
@@ -165,7 +165,7 @@ LIGHTMODBUS_RET_ERROR modbusBeginRequestTCP(ModbusMaster *status)
 	\brief Finalizes a Modbus TCP request
 	\param transactionID Modbus TCP transaction identifier
 	\param unitID Modbus TCP Unit ID
-	\returns MODBUS_GENERAL_ERROR(LENGTH) if the allocated frame has invalid length 
+	\returns MODBUS_GENERAL_ERROR(LENGTH) if the allocated frame has invalid length
 	\returns MODBUS_NO_ERROR() on success
 */
 LIGHTMODBUS_RET_ERROR modbusEndRequestTCP(ModbusMaster *status, uint16_t transactionID, uint8_t unitID)
@@ -208,7 +208,7 @@ LIGHTMODBUS_RET_ERROR modbusParseResponsePDU(
 		return MODBUS_REQUEST_ERROR(LENGTH);
 	if (!responseLength || responseLength > MODBUS_PDU_MAX)
 		return MODBUS_RESPONSE_ERROR(LENGTH);
-	
+
 	uint8_t function = response[0];
 
 	// Handle exception frames
@@ -265,9 +265,9 @@ LIGHTMODBUS_RET_ERROR modbusParseResponseRTU(
 	uint16_t responseLength)
 {
 	// Unpack request
-	const uint8_t *requestPDU;
-	uint16_t requestPDULength;
-	uint8_t requestAddress;
+	const uint8_t *requestPDU = NULL;
+	uint16_t requestPDULength = 0;
+	uint8_t requestAddress    = 0;
 	ModbusError err = modbusUnpackRTU(
 		request,
 		requestLength,
@@ -294,7 +294,7 @@ LIGHTMODBUS_RET_ERROR modbusParseResponseRTU(
 		&responsePDU,
 		&responsePDULength,
 		&responseAddress);
-	
+
 	if (err != MODBUS_OK)
 		return MODBUS_MAKE_ERROR(MODBUS_ERROR_SOURCE_RESPONSE, err);
 
@@ -361,7 +361,7 @@ LIGHTMODBUS_RET_ERROR modbusParseResponseTCP(
 		&responsePDULength,
 		&responseTransactionID,
 		&responseUnitID);
-	
+
 	if (err != MODBUS_OK)
 		return MODBUS_MAKE_ERROR(MODBUS_ERROR_SOURCE_RESPONSE, err);
 

--- a/include/lightmodbus/slave.impl.h
+++ b/include/lightmodbus/slave.impl.h
@@ -111,7 +111,7 @@ void modbusSlaveDestroy(ModbusSlave *status)
 		response frame is going to be discarded (when the request was broadcast).
 
 	\warning This function expects ModbusSlave::response::pduOffset and
-	ModbusSlave::response::padding to be set properly! If you're looking for a 
+	ModbusSlave::response::padding to be set properly! If you're looking for a
 	function to manually build an exception please use modbusBuildExceptionPDU(),
 	modbusBuildExceptionRTU() or modbusBuildExceptionTCP()
 */
@@ -147,7 +147,7 @@ LIGHTMODBUS_RET_ERROR modbusBuildExceptionPDU(
 {
 	status->response.pduOffset = 0;
 	status->response.padding = 0;
-	
+
 	ModbusErrorInfo err = modbusBuildException(status, function, code);
 	if (!modbusIsOk(err))
 		return err;
@@ -176,9 +176,9 @@ LIGHTMODBUS_RET_ERROR modbusBuildExceptionRTU(
 
 	status->response.pduOffset = MODBUS_RTU_PDU_OFFSET;
 	status->response.padding = MODBUS_RTU_ADU_PADDING;
-	
+
 	ModbusErrorInfo errinfo = modbusBuildException(status, function, code);
-	
+
 	if (!modbusIsOk(errinfo))
 		return errinfo;
 
@@ -186,7 +186,7 @@ LIGHTMODBUS_RET_ERROR modbusBuildExceptionRTU(
 		&status->response.data[0],
 		status->response.length,
 		address);
-		
+
 	// There's literally no reason for modbusPackRTU()
 	// to return MODBUS_ERROR_LENGTH here
 	(void) err;
@@ -196,7 +196,7 @@ LIGHTMODBUS_RET_ERROR modbusBuildExceptionRTU(
 
 /**
 	\brief Builds a Modbus TCP exception
-	\param transactionID transaction ID 
+	\param transactionID transaction ID
 	\param unitID unit ID to be reported in the exception
 	\param function function that reported the exception
 	\param code Modbus exception code
@@ -213,9 +213,9 @@ LIGHTMODBUS_RET_ERROR modbusBuildExceptionTCP(
 {
 	status->response.pduOffset = MODBUS_TCP_PDU_OFFSET;
 	status->response.padding = MODBUS_TCP_ADU_PADDING;
-	
+
 	ModbusErrorInfo errinfo = modbusBuildException(status, function, code);
-	
+
 	if (!modbusIsOk(errinfo))
 		return errinfo;
 
@@ -240,10 +240,10 @@ LIGHTMODBUS_RET_ERROR modbusBuildExceptionTCP(
 	\returns Any errors from parsing functions
 
 	\warning This function expects ModbusSlave::response::pduOffset and
-	ModbusSlave::response::padding to be set properly! If you're looking for a 
+	ModbusSlave::response::padding to be set properly! If you're looking for a
 	function to parse PDU and generate a PDU response, please use modbusParseRequestPDU() instead.
 
-	\warning The response frame can only be accessed if modbusIsOk() called 
+	\warning The response frame can only be accessed if modbusIsOk() called
 		on the return value of this function evaluates to true.
 */
 LIGHTMODBUS_RET_ERROR modbusParseRequest(ModbusSlave *status, const uint8_t *request, uint8_t requestLength)
@@ -266,7 +266,7 @@ LIGHTMODBUS_RET_ERROR modbusParseRequest(ModbusSlave *status, const uint8_t *req
 	\returns MODBUS_REQUEST_ERROR(LENGTH) if length of the frame is invalid
 	\returns Any errors from parsing functions
 
-	\warning The response frame can only be accessed if modbusIsOk() called 
+	\warning The response frame can only be accessed if modbusIsOk() called
 		on the return value from this function evaluates to true.
 
 	\warning The `requestLength` argument is  of type `uint8_t` and not `uint16_t`
@@ -293,15 +293,15 @@ LIGHTMODBUS_RET_ERROR modbusParseRequestPDU(ModbusSlave *status, const uint8_t *
 	\returns MODBUS_GENERAL_ERROR(LENGTH) if the resulting response frame has invalid length
 	\returns Any errors from parsing functions
 
-	\warning The response frame can only be accessed if modbusIsOk() called 
+	\warning The response frame can only be accessed if modbusIsOk() called
 		on the return value of this function evaluates to true.
 */
 LIGHTMODBUS_RET_ERROR modbusParseRequestRTU(ModbusSlave *status, uint8_t slaveAddress, const uint8_t *request, uint16_t requestLength)
 {
 	// Unpack the request
-	const uint8_t *pdu;
-	uint16_t pduLength;
-	uint8_t requestAddress;
+	const uint8_t *pdu     = NULL;
+	uint16_t pduLength     = 0;
+	uint8_t requestAddress = 0;
 	ModbusError err = modbusUnpackRTU(
 		request,
 		requestLength,
@@ -323,7 +323,7 @@ LIGHTMODBUS_RET_ERROR modbusParseRequestRTU(ModbusSlave *status, uint8_t slaveAd
 	modbusBufferModeRTU(&status->response);
 	if (!modbusIsOk(errinfo = modbusParseRequest(status, pdu, pduLength)))
 		return errinfo;
-	
+
 	if (status->response.length)
 	{
 		// Discard any response frames if the request
@@ -343,7 +343,7 @@ LIGHTMODBUS_RET_ERROR modbusParseRequestRTU(ModbusSlave *status, uint8_t slaveAd
 		if (err != MODBUS_OK)
 			return MODBUS_MAKE_ERROR(MODBUS_ERROR_SOURCE_GENERAL, err);
 	}
-	
+
 	return MODBUS_NO_ERROR();
 }
 
@@ -356,7 +356,7 @@ LIGHTMODBUS_RET_ERROR modbusParseRequestRTU(ModbusSlave *status, uint8_t slaveAd
 	\returns MODBUS_GENERAL_ERROR(LENGTH) if the resulting response frame has invalid length
 	\returns Any errors from parsing functions
 
-	\warning The response frame can only be accessed if modbusIsOk() called 
+	\warning The response frame can only be accessed if modbusIsOk() called
 		on the return value of this function evaluates to true.
 */
 LIGHTMODBUS_RET_ERROR modbusParseRequestTCP(ModbusSlave *status, const uint8_t *request, uint16_t requestLength)
@@ -377,7 +377,7 @@ LIGHTMODBUS_RET_ERROR modbusParseRequestTCP(ModbusSlave *status, const uint8_t *
 
 	if (err != MODBUS_OK)
 		return MODBUS_MAKE_ERROR(MODBUS_ERROR_SOURCE_REQUEST, err);
-	
+
 	// Parse the request
 	ModbusErrorInfo errinfo;
 	modbusBufferModeTCP(&status->response);


### PR DESCRIPTION
I've recently tried to use this library with ESP-IDF v5.3 and apparently they added the `-Werror=maybe-uninitialized` to the compilation process, which causes an error because sometimes variables in liblightmodbus are left without initialization. I simply gave a default value (0) in all such cases.